### PR TITLE
Logical Types & Glue Crawler type uniontype workaround

### DIFF
--- a/create_statement_creator/athena_schema.py
+++ b/create_statement_creator/athena_schema.py
@@ -7,11 +7,8 @@ def create_athena_schema_from_avro(avro_schema_literal: str) -> str:
 
     column_schemas = []
     for field in avro_schema.fields:
-        print(f'processing {field}\n\n')
         column_name = field.name.lower()
-        print(f'column_name {column_name}\n\n')
         column_type = create_athena_column_schema(field.type)
-        print(f'column_type {column_type}\n\n')
         column_schemas.append(f"`{column_name}` {column_type}")
 
     return ', '.join(column_schemas)

--- a/create_statement_creator/athena_schema.py
+++ b/create_statement_creator/athena_schema.py
@@ -1,19 +1,23 @@
-from avro.schema import Parse, RecordSchema, PrimitiveSchema, ArraySchema, MapSchema, EnumSchema, UnionSchema, FixedSchema
-
+from avro.schema import parse, RecordSchema, PrimitiveSchema, ArraySchema, MapSchema, EnumSchema, UnionSchema, FixedSchema, \
+    BytesDecimalSchema
 
 def create_athena_schema_from_avro(avro_schema_literal: str) -> str:
-    avro_schema: RecordSchema = Parse(avro_schema_literal)
+    avro_schema: RecordSchema = parse(avro_schema_literal)
 
     column_schemas = []
     for field in avro_schema.fields:
+        print(f'processing {field}\n\n')
         column_name = field.name.lower()
+        print(f'column_name {column_name}\n\n')
         column_type = create_athena_column_schema(field.type)
+        print(f'column_type {column_type}\n\n')
         column_schemas.append(f"`{column_name}` {column_type}")
 
     return ', '.join(column_schemas)
 
 
 def create_athena_column_schema(avro_schema) -> str:
+    print(f'create_column {type(avro_schema)} with type {avro_schema.type}:\n {str(avro_schema)}\n\n')
     if type(avro_schema) == PrimitiveSchema:
         return rename_type_names(avro_schema.type)
 
@@ -45,6 +49,9 @@ def create_athena_column_schema(avro_schema) -> str:
 
     elif type(avro_schema) in [EnumSchema, FixedSchema]:
         return 'string'
+
+    elif type(avro_schema) == BytesDecimalSchema:
+        return f'decimal({avro_schema.precision}, {avro_schema.scale})'
 
     else:
         raise Exception(f'unknown avro schema type {avro_schema.type}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-avro-python3==1.9.1
+avro==1.10.0


### PR DESCRIPTION
Adds support for logical types: 

* BytesDecimal
* FixedDecimal
* Date
* TimeMillis
* TimeMicros
* TimestampMillis
* TimestampMicros

Also mimics AWS Glue Crawler in creating structs for union types:
`struct<member0: int, member1: long>`